### PR TITLE
Issue #137 - ctools update

### DIFF
--- a/ding_user_frontend.make
+++ b/ding_user_frontend.make
@@ -3,7 +3,7 @@ api = 2
 
 ; Projects
 projects[ctools][subdir] = "contrib"
-projects[ctools][version] = "1.4"
+projects[ctools][version] = "1.5"
 
 projects[date][subdir] = "contrib"
 projects[date][version] = "2.8"


### PR DESCRIPTION
Updated ctools which fixes PHP 5.3 warnings.